### PR TITLE
Refactor game RNG provider to avoid initialization cycle

### DIFF
--- a/test/game_flow_test.dart
+++ b/test/game_flow_test.dart
@@ -7,14 +7,14 @@ import 'package:yatzy_tr/features/game/domain/scoring_engine.dart';
 void main() {
   late GameController controller;
   late ScoringEngine scoringEngine;
-  late RNG rng;
+  late RngFactory rngFactory;
 
   setUp(() {
     scoringEngine = const ScoringEngine();
-    rng = RNG(seed: 42); // Deterministic seed
+    rngFactory = ({int? seed}) => RNG(seed: seed);
     controller = GameController(
       scoringEngine: scoringEngine,
-      rng: rng,
+      rngFactory: rngFactory,
     );
   });
 


### PR DESCRIPTION
## Summary
- provide an RNG factory from `rngProvider` so it no longer depends on the game state
- update `GameController` to create a seeded RNG when a game starts using the injected factory
- adjust the game flow test harness to use the new RNG factory entry point

## Testing
- Not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e597dd5c208329a86831728abf6dc7